### PR TITLE
sparse variant of the naive fusion

### DIFF
--- a/src/merge_stardist_masks/naive_fusion.py
+++ b/src/merge_stardist_masks/naive_fusion.py
@@ -22,9 +22,7 @@ ArrayLike = npt.ArrayLike
 
 def mesh_from_shape(shape: Tuple[int, ...]) -> npt.NDArray[np.int_]:
     """Convenience function to generate a mesh."""
-    offsets = []
-    for i in range(len(shape)):
-        offsets.append(np.arange(shape[i]))
+    offsets = [np.arange(s) for s in shape]
     mesh = np.meshgrid(*offsets, indexing="ij")  # type: ignore [no-untyped-call]
     return np.stack(mesh, axis=-1)
 
@@ -159,7 +157,7 @@ def inflate_array(
     # len(new_shape) will be len(grid)
     new_shape = tuple(s * g for s, g in zip(x.shape, grid))
     if x.ndim > len(new_shape):
-        new_shape = new_shape + tuple(x.shape[len(new_shape) :])
+        new_shape = new_shape + x.shape[len(new_shape) :]
     new_x = np.full(new_shape, default_value, dtype=x.dtype)
     slices = []
     for i in range(len(new_shape)):
@@ -511,7 +509,7 @@ def naive_fusion_anisotropic_grid(
     # run max_dist before inflating dists
     max_dist = int(dists.max() * 2)
     # this could also be done with np.repeat, but for probs it is important that some
-    # of the repeatet values are -1, as they should not be considered.
+    # of the repeated values are -1, as they should not be considered.
     new_probs = inflate_array(probs, grid, default_value=-1)
     points = inflate_array(points_from_grid(probs.shape, grid), grid, default_value=0)
 
@@ -614,6 +612,137 @@ def naive_fusion_anisotropic_grid(
         paint_in = lbl[slices]
         paint_in[new_shape] = current_id
         lbl[slices] = paint_in
+
+        current_id += 1
+
+    return lbl
+
+
+def naive_fusion_sparse(
+    dists: npt.NDArray[np.double],
+    probs: npt.NDArray[np.double],
+    points: npt.NDArray[int],
+    lbl_shape: Tuple[int, ...],
+    grid: Tuple[int, ...],
+    rays: Optional[Rays_Base] = None,
+    no_slicing: Optional[bool] = False,
+    max_full_overlaps: Optional[int] = 2,
+    erase_probs_at_full_overlap: Optional[bool] = False,
+) -> npt.NDArray[int]:
+    """Merge sparse overlapping masks given by dists, probs, points.
+
+
+    Example:
+        >>> from merge_stardist_masks.naive_fusion import naive_fusion_sparse
+        >>> probs, dists, points = model.predict_sparse(img)
+        >>> lbl = naive_fusion_sparse(dists, probs, points, img.shape)
+    """
+    from tqdm import tqdm
+    from math import ceil
+
+
+    assert dists.shape[0] == probs.shape[0] == points.shape[0] \
+        , f'The shapes {dists.shape}, {probs.shape}, {points.shape}' + \
+           ' (dists, probs, points) does not match for sparse fusion!'
+
+    shape = tuple(ceil(s / g) for s, g in zip(lbl_shape, grid))
+    poly_to_label = get_poly_to_label(shape, rays)
+
+    lbl = np.zeros(lbl_shape, dtype=np.uint16)
+
+    prob_order = np.argsort(probs)[::-1]
+    subvolume_max_edge_length = int(dists.max() * 2)
+
+
+    if no_slicing:
+        this_slice_point = no_slicing_slice_point
+    else:
+        this_slice_point = slice_point
+
+    current_id = 1
+    for prob_idx in tqdm(prob_order):
+        if probs[prob_idx] == -1:
+            continue
+        else:
+            probs[prob_idx] = -1
+
+        current_dists = dists[prob_idx, :]
+
+        # Get subvolume for calculations       
+        subvolume_crop, subvolume_center = this_slice_point(
+            points[prob_idx, :],
+            subvolume_max_edge_length
+        )
+
+        subvolume_before = lbl[subvolume_crop]
+        subvolume_shape = subvolume_before.shape
+
+        subvolume_mask = poly_to_label(current_dists, subvolume_center, subvolume_shape) == 1
+
+        # TODO(erjel): Prevent overwrite?
+        #subvolume_mask = np.logical_and(
+        #    subvolume_before == 0,
+        #    subvolume_mask
+        #)
+        
+        # Check for other points in the slice
+        subvolume_offset = np.array([[0 if s.start is None else s.start for s in subvolume_crop]])
+
+        points_with_offset = points - subvolume_offset
+        is_in_subvolume = np.logical_and(
+            np.all(points_with_offset >= 0, axis=1),
+            np.all(points_with_offset < np.array(subvolume_shape), axis=1),
+        )
+
+        idx_is_in_subvolume = np.where(is_in_subvolume)[0]
+
+        full_overlaps = 0
+        while True:
+            if full_overlaps > max_full_overlaps:
+                break
+
+            idcs_in_subvolume_mask = idx_is_in_subvolume[ \
+                    subvolume_mask[tuple(points_with_offset[is_in_subvolume])] \
+            ]
+
+            probs_in_subvolume_mask = probs[idcs_in_subvolume_mask]
+
+            if not np.any(probs_in_subvolume_mask > 0):
+                break
+
+            dists_in_subvolume_mask = dists[idcs_in_subvolume_mask, :]
+            points_in_subvolume_mask = points_with_offset[idcs_in_subvolume_mask, :]
+
+            prob_idx_subvolume_mask = np.argmax(probs_in_subvolume_mask)
+            probs[idcs_in_subvolume_mask[prob_idx_subvolume_mask]] = -1
+
+            additional_shape: npt.NDArray[bool] = (
+                poly_to_label(
+                    dists_in_subvolume_mask[prob_idx_subvolume_mask, :],
+                    points_in_subvolume_mask[prob_idx_subvolume_mask, :],
+                    subvolume_shape
+                ) == 1
+            )
+            # TODO(erjel): Prevent overwrite?
+            # additional_shape = np.logical_and(
+            #   subvolume_before == 0,
+            #   additional_shape   
+            # )
+
+            size_of_current_shape = np.sum(subvolume_mask)
+
+            subvolume_mask = np.logical_or(
+                subvolume_mask,
+                additional_shape
+            )
+            if size_of_current_shape == np.sum(subvolume_mask):
+                full_overlaps += 1
+                if erase_probs_at_full_overlap:
+                    probs[idcs_in_subvolume_mask] = -1
+
+        ## Write slice in lbl
+        subvolume_before[subvolume_mask] = current_id
+        lbl[subvolume_crop] = subvolume_before
 
         current_id += 1
 

--- a/tests/test_naive_fusion.py
+++ b/tests/test_naive_fusion.py
@@ -568,3 +568,31 @@ def test_get_poly_list_to_label() -> None:
     with pytest.raises(ValueError):
         # shape must be of length 2 or 3
         nf.get_poly_list_to_label((2, 3, 4, 5), None)
+
+
+def test_naive_fusion_sparse_2d() -> None:
+    n_polys = 2
+    n_rays = 3
+
+    grid = (1,1)
+
+    dists = np.zeros((n_polys, n_rays))
+    probs = np.zeros(n_polys)
+    points = np.zeros((n_polys, 2), dtype=int)
+
+    probs = np.array([0.8, 0.9])
+    dists = np.array([
+        [3, 3, 3, 3],
+        [2, 2, 2, 2],
+    ])
+
+    points = np.array([
+        [3, 3],
+        [7, 7],
+    ])
+
+    lbl_shape = (10, 10)
+
+    lbl = nf.naive_fusion_sparse(dists, probs, points, lbl_shape, grid)  
+    
+    print(lbl)  


### PR DESCRIPTION
It is probably a good idea to provide a naive fusion which also works with the `predict_sparse`.

I just wrote down my (naive) ideas how this could look like. 

ToDos:

- [x] Implement tests
- [ ] Add grid calculations
- [ ] add 2D variant (yet, I do not see any dimension dependency)
- [ ] test with production dataset
- [ ] Make naming consistent with rest of the code

Signed version of #79 